### PR TITLE
Build for kernel 3.10.0-1062

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Compile using mock:
 ```
 wget http://downloads.asterisk.org/pub/telephony/dahdi-linux/dahdi-linux-2.11.1.tar.gz
 
-mock --resultdir=. -r nethserver-7-x86_64 -D 'dist .ns7' -D 'version 2.11.1' -D 'release 3.10.0_957.el7' --buildsrpm --spec dahdi-linux-kmod.spec --sources .
+mock --resultdir=. -r nethserver-7-x86_64 -D 'dist .ns7' -D 'version 2.11.1' -D 'release 3.10.0_1062.el7' --buildsrpm --spec dahdi-linux-kmod.spec --sources .
 
-mock --resultdir=. -r nethserver-7-x86_64 -D 'dist .ns7' -D 'version 2.11.1' -D 'release 3.10.0_957.el7'  dahdi-linux-kmod-*.src.rpm
+mock --resultdir=. -r nethserver-7-x86_64 -D 'dist .ns7' -D 'version 2.11.1' -D 'release 3.10.0_1062.el7'  dahdi-linux-kmod-*.src.rpm
 ```
 
 If you need to increase the current spec release, add it to the dist tag:

--- a/dahdi-linux-kmod.spec
+++ b/dahdi-linux-kmod.spec
@@ -1,5 +1,5 @@
 %define   kmodtool bash /usr/lib/rpm/redhat/kmodtool
-%{!?kversion: %define kversion 3.10.0-957.el7}
+%{!?kversion: %define kversion 3.10.0-1062.el7}
 
 %define kmod_name dahdi-linux
 %define kverrel %(%{kmodtool} verrel %{?kversion} 2>/dev/null)


### PR DESCRIPTION
This should be built with dist flag  set to `.4.ns7`

NethServer/dev#5831